### PR TITLE
Add homepage-field to blueprints.yaml

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -6,6 +6,7 @@ author:
   name: Team Grav
   email: devs@getgrav.org
   url: http://getgrav.org
+homepage: https://github.com/getgrav/grav-plugin-markdown-notices
 license: MIT
 
 form:


### PR DESCRIPTION
Adds a required blueprints-field per the [docs](https://learn.getgrav.org/advanced/grav-development#themeplugin-release-process), specifically item 3: "Contains a blueprints.yaml file with all required fields. [Example Here](https://github.com/getgrav/grav-theme-antimatter/blob/develop/blueprints.yaml)".