### PR TITLE
Tweak of notices.css

### DIFF
--- a/assets/notices.css
+++ b/assets/notices.css
@@ -6,7 +6,7 @@
     border-radius: 3px;
 }
 
-.notices p,ul,ol {
+.notices p, .notices ul, .notices ol {
     margin-bottom: 0;
 }
 

--- a/assets/notices.css
+++ b/assets/notices.css
@@ -1,32 +1,35 @@
 .notices {
-    padding: 1px 1px 1px 30px;
-    margin: 15px 0;
+    padding: 15px;
+    margin: 1rem 0;
+    border-width: 1px 1px 1px 10px;
+    border-style: solid;
+    border-radius: 3px;
 }
 
-.notices p {
-
+.notices p,ul,ol {
+    margin-bottom: 0;
 }
 
 .notices.yellow {
-    border-left: 10px solid #f0ad4e;
+    border-color: #f0ad4e;
     background: #fcf8f2;
     color: #df8a13;
 }
 
 .notices.red {
-    border-left: 10px solid #d9534f;
+    border-color: #d9534f;
     background: #fdf7f7;
     color: #b52b27;
 }
 
 .notices.blue {
-    border-left: 10px solid #5bc0de;
+    border-color: #5bc0de;
     background: #f4f8fa;
     color: #28a1c5;
 }
 
 .notices.green {
-    border-left: 10px solid #5cb85c;
+	border-color: #5cb85c;
     background: #f1f9f1;
     color: #3d8b3d;
 }


### PR DESCRIPTION
Some modifications in notices.css:
- padding and margin adjusted
- border properties moved to the main class
- color classes include only border color
- added margin: 0 for p, ul and ol inside .notices for even spacing of text inside the box.

Lists can be used inside the notices, but you have to manually insert list markdown inside the notice (not using the list button in the Admin page editor):

! List:
! * list item 1
! * list item 2