### PR TITLE
Ability to specify own base classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You will output the following HTML
 </div>
 ```
 
-The `yellow` class is determined by the `level_classes` in the configuration.  You can customize this as you need.
+The `notices` class determined by the `base_classes` and `yellow` class is determined by the `level_classes` in the configuration. You can customize this as you need.
 
 ```
 !! Lorem ipsum dolor sit amet, **consectetur adipiscing** elit. Mauris feugiat quam erat, ut iaculis diam posuere nec.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simply copy the `user/plugins/markdown-notices/markdown-notices.yaml` into `user
 ```
 enabled: true
 built_in_css: true
-base_classes: [notices]
+base_classes: 'notices'
 level_classes: [yellow, red, blue, green]
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Simply copy the `user/plugins/markdown-notices/markdown-notices.yaml` into `user
 ```
 enabled: true
 built_in_css: true
+base_classes: [notices]
 level_classes: [yellow, red, blue, green]
 ```
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,6 +1,6 @@
-name: Markdown Notices
+name: 'Markdown Notices'
 version: 1.0.1
-description: "Adds the ability to render notices blocks in Markdown"
+description: 'Adds the ability to render notices blocks in Markdown'
 icon: asterisk
 author:
   name: Team Grav
@@ -14,32 +14,42 @@ form:
   fields:
     enabled:
       type: toggle
-      label: Plugin status
+      label: PLUGIN_ADMIN.PLUGIN_STATUS
       highlight: 1
       default: 0
       options:
-        1: Enabled
-        0: Disabled
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
 
     built_in_css:
       type: toggle
-      label: Use built in CSS
+      label: PLUGIN_MARKDOWN_NOTICES.USE_BUILT_IN_CSS
       highlight: 1
       default: 1
       options:
-        1: Enabled
-        0: Disabled
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
       validate:
         type: bool
 
+    base_classes:
+      type: selectize
+      label: PLUGIN_MARKDOWN_NOTICES.BASE_CLASSES
+      size: large
+      placeholder: PLUGIN_MARKDOWN_NOTICES.BASE_CLASSES_PLACEHOLDER
+      help: PLUGIN_MARKDOWN_NOTICES.HELP
+      classes: fancy
+      validate:
+        type: commalist
+
     level_classes:
-        type: selectize
-        size: large
-        placeholder: "e.g. yellow, red, blue, green"
-        label: Level classes
-        help: The classes to use for each level of notices depth
-        classes: fancy
-        validate:
-            type: commalist
+      type: selectize
+      label: PLUGIN_MARKDOWN_NOTICES.LEVEL_CLASSES
+      size: large
+      placeholder: PLUGIN_MARKDOWN_NOTICES.LEVEL_CLASSES_PLACEHOLDER
+      help: PLUGIN_MARKDOWN_NOTICES.LEVEL_CLASSES_HELP
+      classes: fancy
+      validate:
+        type: commalist

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -42,7 +42,7 @@ form:
       help: PLUGIN_MARKDOWN_NOTICES.HELP
       classes: fancy
       validate:
-        type: commalist
+        type: string
 
     level_classes:
       type: selectize

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,0 +1,29 @@
+en:
+  PLUGIN_MARKDOWN_NOTICES:
+    USE_BUILT_IN_CSS: 'Use built-in CSS'
+    BASE_CLASSES: 'Base classes'
+    BASE_CLASSES_HELP: 'These classes will be added before the class level'
+    BASE_CLASSES_PLACEHOLDER: 'e.g. notices'
+    LEVEL_CLASSES: 'Level classes'
+    LEVEL_CLASSES_HELP: 'The classes to use for each level of notices depth'
+    LEVEL_CLASSES_PLACEHOLDER: 'e.g. yellow, red, blue, green'
+
+ru:
+  PLUGIN_MARKDOWN_NOTICES:
+    USE_BUILT_IN_CSS: 'Использовать встроенный CSS'
+    BASE_CLASSES: 'Базовые классы'
+    BASE_CLASSES_HELP: 'Эти классы будут добавлены до уровня класса'
+    BASE_CLASSES_PLACEHOLDER: 'например notices'
+    LEVEL_CLASSES: 'Классы уровней'
+    LEVEL_CLASSES_HELP: 'Эти классы используются на каждом уровне глубины уведомлений'
+    LEVEL_CLASSES_PLACEHOLDER: 'например yellow, red, blue, green'
+
+uk:
+  PLUGIN_MARKDOWN_NOTICES:
+    USE_BUILT_IN_CSS: 'Використовувати вбудований CSS'
+    BASE_CLASSES: 'Базові класи'
+    BASE_CLASSES_HELP: 'Ці класи будуть додані до рівня класу'
+    BASE_CLASSES_PLACEHOLDER: 'наприклад notices'
+    LEVEL_CLASSES: 'Класи рівнів'
+    LEVEL_CLASSES_HELP: 'Ці класи використовуються на кожному рівні глибини повідомлень'
+    LEVEL_CLASSES_PLACEHOLDER: 'наприклад yellow, red, blue, green'

--- a/markdown-notices.php
+++ b/markdown-notices.php
@@ -1,11 +1,12 @@
 <?php
 namespace Grav\Plugin;
 
-use \Grav\Common\Plugin;
+use Grav\Common\Plugin;
 use RocketTheme\Toolbox\Event\Event;
 
 class MarkdownNoticesPlugin extends Plugin
 {
+    protected $base_classes;
     protected $level_classes;
 
     /**
@@ -28,12 +29,11 @@ class MarkdownNoticesPlugin extends Plugin
         $markdown->blockNotices = function($Line) {
 
             $this->level_classes = $this->config->get('plugins.markdown-notices.level_classes');
+            $this->base_classes  = $this->config->get('plugins.markdown-notices.base_classes');
 
             if (preg_match('/^(!{1,'.count($this->level_classes).'})[ ]+(.*)/', $Line['text'], $matches))
             {
                 $level = strlen($matches[1]) - 1;
-
-
 
                 // if we have more levels than we support
                 if ($level > count($this->level_classes)-1)
@@ -42,17 +42,18 @@ class MarkdownNoticesPlugin extends Plugin
                 }
 
                 $text = $matches[2];
+                $base_classes = (empty($this->base_classes)) ? '' : str_replace(',', ' ', $this->base_classes) . ' ';
 
-                $Block = array(
-                    'element' => array(
+                $Block = [
+                    'element' => [
                         'name' => 'div',
                         'handler' => 'lines',
-                        'attributes' => array(
-                            'class' => 'notices '. $this->level_classes[$level],
-                        ),
+                        'attributes' => [
+                            'class' => $base_classes . $this->level_classes[$level],
+                        ],
                         'text' => (array) $text,
-                    ),
-                );
+                    ],
+                ];
 
                 return $Block;
             }
@@ -80,5 +81,4 @@ class MarkdownNoticesPlugin extends Plugin
                 ->add('plugin://markdown-notices/assets/notices.css');
         }
     }
-
 }

--- a/markdown-notices.yaml
+++ b/markdown-notices.yaml
@@ -1,3 +1,4 @@
 enabled: true
 built_in_css: true
+base_classes: [notices]
 level_classes: [yellow, red, blue, green]

--- a/markdown-notices.yaml
+++ b/markdown-notices.yaml
@@ -1,4 +1,4 @@
 enabled: true
 built_in_css: true
-base_classes: [notices]
+base_classes: 'notices'
 level_classes: [yellow, red, blue, green]


### PR DESCRIPTION
Added the ability to specify own base classes for level classes. This is convenient when we use css frameworks with their own notification structure. For example bootstrap with its `alert alert-{info, warning, danger}`.
Added language file and a couple of translations.

@rhukster 