### PR TITLE
Fix padding around notice blocks

### DIFF
--- a/assets/notices.css
+++ b/assets/notices.css
@@ -1,10 +1,10 @@
 .notices {
-    padding: 1px 1px 1px 30px;
+    padding: 30px;
     margin: 15px 0;
 }
 
 .notices p {
-
+    margin: 0;
 }
 
 .notices.yellow {


### PR DESCRIPTION
Because blocks are using paragraph tags, top and bottom block padding is dependent on the margin of the global `<p>` style configuration. For example, in `learn2-git` theme global paragraph configuration has a top/bottom margin of 1.7rem (~30px). Current CSS matches this, however it becomes an issue when one wants to use markdown blocks in other themes, where different font is used, let's say, Arial with 1.2rem for paragraph top/bottom margins.

We solve this issue by resetting margin of paragraph tags inside notices to zero and purely relying just on padding to provide a spacing.

This correctly fixes a padding issue mentioned in https://github.com/getgrav/grav-plugin-markdown-notices/issues/5 and later reverted in https://github.com/getgrav/grav-plugin-markdown-notices/pull/6 .

This also fixes an issue mentioned in https://github.com/getgrav/grav-plugin-markdown-notices/issues/24 with current default themes where there is no right padding:
<img width="1563" height="340" alt="image" src="https://github.com/user-attachments/assets/6e71a5b0-3816-4b43-88ca-01341d34eebf" />
